### PR TITLE
Correct V1 API Deprecation Notice

### DIFF
--- a/api/swagger_v1.yaml
+++ b/api/swagger_v1.yaml
@@ -12,9 +12,9 @@ info:
     communicating with components via Redfish.
     It also allows administrators to create partitions and groups for other uses.
 
-    ## Deprecation Notice: V1 of the HMS service has been deprecated as of CSM version 1.4. 
-    The V1 HSM API’s will be removed in the CSM version 1.6 release. 
-    All consumers of the V1 HSM API interface will need to move to the V2 interface prior to the CSM 1.6 release.
+    ## Deprecation Notice: V1 of the HMS service has been deprecated as of CSM version 0.9.3. 
+    The V1 HSM API’s will be removed in the CSM version 1.3 release. 
+    All consumers of the V1 HSM API interface will need to move to the V2 interface prior to the CSM 1.3 release.
 
     ## Resources
 

--- a/api/swagger_v2.yaml
+++ b/api/swagger_v2.yaml
@@ -12,9 +12,9 @@ info:
     communicating with components via Redfish.
     It also allows administrators to create partitions and groups for other uses.
     
-    ## Deprecation Notice: V1 of the HMS service has been deprecated as of CSM version 1.4. 
-    The V1 HSM API’s will be removed in the CSM version 1.6 release. 
-    All consumers of the V1 HSM API interface will need to move to the V2 interface prior to the CSM 1.6 release.
+    ## Deprecation Notice: V1 of the HMS service has been deprecated as of CSM version 0.9.3. 
+    The V1 HSM API’s will be removed in the CSM version 1.3 release. 
+    All consumers of the V1 HSM API interface will need to move to the V2 interface prior to the CSM 1.3 release.
     
     ## Resources
 


### PR DESCRIPTION
### Summary and Scope

The deprecation notice for HSM's V1 API had the incorrect release versions. This corrects it. 

### Issues and Related PRs

* Resolves CASMHMS-5003

### Testing

Swagger comment change only.

### Risks and Mitigations

None