### PR TITLE
Fixed type for BaseModuleType in the openapi docs

### DIFF
--- a/.license_check.yaml
+++ b/.license_check.yaml
@@ -1,0 +1,3 @@
+add_exclude:
+  - ".license_check.yaml"
+  - "*/*.yaml"

--- a/api/swagger_v2.yaml
+++ b/api/swagger_v2.yaml
@@ -9108,7 +9108,7 @@ definitions:
           - SO_DIMM_16b
           - SO_DIMM_32b
         readOnly: true
-        type: number
+        type: string
       BusWidthBits:
         description: Bus width in bits.
         readOnly: true


### PR DESCRIPTION
## Summary and Scope

Fix lint errors in the openapi doc.

## Issues and Related PRs

* Resolves CASMHMS-5401

## Testing
Looked at the results in: https://github.com/swagger-api/swagger-editor
```
docker run --rm -p 80:8080 -v $(pwd):/tmp -e SWAGGER_FILE=/tmp/api/swagger_v2.yaml swaggerapi/swagger-editor
```

Looked at the results from: https://github.com/Redocly/redocly-cli
```
docker run --rm -v $PWD:/spec redocly/openapi-cli lint api/swagger_v2.yaml
```

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
