### PR TITLE
CASMHMS-5608 Update internal HMS documentation for Helm CT tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -219,8 +219,10 @@ https://github.com/Cray-HPE/hms-smd/blob/master/api/swagger_v2.yaml (current)
 
 ## SMD CT Testing
 
-This repository builds and publishes the cray-smd-test image along with the service itself containing tests that verify SMD on live Shasta systems. The tests are invoked via helm test.
-The version of the cray-smd-test image should always match the version of cray-smd image (vX.Y.Z (build metadata not withstanding)).
+In addition to the service itself, this repository builds and publishes cray-smd-test images containing tests that verify HSM
+on live Shasta systems. The tests are invoked via helm test as part of the Continuous Test (CT) framework during CSM installs
+and upgrades. The version of the cray-smd-test image (vX.Y.Z) should match the version of the cray-smd image being tested, both
+of which are specified in the helm chart for the service.
 
 ## smd Features
 


### PR DESCRIPTION
### Summary and Scope

- Update CT testing section of README for new Helm-based tests which replaces the former RPM-based tests.
- Assorted README cleanup.

### Issues and Related PRs

* Partially resolves CASMHMS-5608.

### Testing

- Rendered README updates and viewed them to verify that they look as expected.
- No testing performed due to documentation change only.

Was a fresh Install tested? N/A
Was an Upgrade tested? N/A
Was a Downgrade tested? N/A

### Risks and Mitigations

None, README change only.