### PR TITLE
fix DiscoveryInfo key names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1] - 2023-04-26
+
+### Fixed
+
+- Incorrect DiscoveryInfo key names in the swagger spec.  Specifically, LastAttempt -> LastDiscoveryAttempt and LastStatus -> LastDiscoveryStatus
+
 ## [2.8.0] - 2023-05-03
 
 ### Added

--- a/api/swagger_v2.yaml
+++ b/api/swagger_v2.yaml
@@ -3134,7 +3134,7 @@ paths:
           description: >-
             Retrieve the RedfishEndpoint with the given IP address. A blank
             string will get Redfish endpoints without IP addresses.
-        - name: laststatus
+        - name: lastdiscoverystatus
           in: query
           type: string
           description: >-
@@ -9757,12 +9757,12 @@ definitions:
         description: >-
           Contains info about the discovery status of the given endpoint.
         properties:
-          LastAttempt:
+          LastDiscoveryAttempt:
             description: The time the last discovery attempt took place.
             format: date-time
             readOnly: true
             type: string
-          LastStatus:
+          LastDiscoveryStatus:
             description: Describes the outcome of the last discovery attempt.
             enum:
               - EndpointInvalid


### PR DESCRIPTION
## Summary and Scope

Sets the correct key names for `DiscoveryInfo`

## Issues and Related PRs



* Relates to 

## Testing

Tested on:

  * Local development environment

Test description:

Used the spec to generate a go library and tested unmarshalling a redfishEndpoint.

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
