### PR TITLE
In the swagger docs moved VirtualNode up in the list

### DIFF
--- a/api/swagger_v2.yaml
+++ b/api/swagger_v2.yaml
@@ -1423,6 +1423,7 @@ paths:
             - MgmtHLSwitch
             - CDUMgmtSwitch
             - Node
+            - VirtualNode
             - Processor
             - Drive
             - StorageGroup
@@ -1437,7 +1438,6 @@ paths:
             - HSNLink
             - HSNConnector
             - INVALID
-            - VirtualNode
         - $ref: '#/parameters/compStateParam'
         - $ref: '#/parameters/compFlagParam'
         - $ref: '#/parameters/compRoleParam'
@@ -11795,6 +11795,7 @@ definitions:
       - MgmtHLSwitch
       - CDUMgmtSwitch
       - Node
+      - VirtualNode
       - Processor
       - Drive
       - StorageGroup
@@ -11809,7 +11810,6 @@ definitions:
       - HSNLink
       - HSNConnector
       - INVALID
-      - VirtualNode
     type: string
     readOnly: true
     example: Node
@@ -12084,6 +12084,7 @@ parameters:
       - MgmtHLSwitch
       - CDUMgmtSwitch
       - Node
+      - VirtualNode
       - Processor
       - Drive
       - StorageGroup
@@ -12098,7 +12099,6 @@ parameters:
       - HSNLink
       - HSNConnector
       - INVALID
-      - VirtualNode
   compStateParam:
     name: state
     in: query


### PR DESCRIPTION

## Summary and Scope

Changed the order of VirtualNode in the list of types in the swagger file.

This change makes the output from cray cli very slightly nicer.

Before this change, VirtualNode is at the end of the list after INVALID
```
cray hsm state components list --help
...
  --type [CDU|CabinetCDU|CabinetPDU|CabinetPDUOutlet|CabinetPDUPowerConnector|CabinetPDUController|Cabinet|Chassis|ChassisBMC|CMMRectifier|CMMFpga|CEC|ComputeModule|RouterModule|NodeBMC|NodeEnclosure|NodeEnclosurePowerSupply|HSNBoard|MgmtSwitch|MgmtHLSwitch|CDUMgmtSwitch|Node|Processor|Drive|StorageGroup|NodeNIC|Memory|NodeAccel|NodeAccelRiser|NodeFpga|HSNAsic|RouterFpga|RouterBMC|HSNLink|HSNConnector|INVALID|VirtualNode]
```

After this change and after updating the swagger file in cray cli, the VirtualNode is after Node in the list.
```
cray hsm state components list --help
...
  --type [CDU|CabinetCDU|CabinetPDU|CabinetPDUOutlet|CabinetPDUPowerConnector|CabinetPDUController|Cabinet|Chassis|ChassisBMC|CMMRectifier|CMMFpga|CEC|ComputeModule|RouterModule|NodeBMC|NodeEnclosure|NodeEnclosurePowerSupply|HSNBoard|MgmtSwitch|MgmtHLSwitch|CDUMgmtSwitch|Node|VirtualNode|Processor|Drive|StorageGroup|NodeNIC|Memory|NodeAccel|NodeAccelRiser|NodeFpga|HSNAsic|RouterFpga|RouterBMC|HSNLink|HSNConnector|INVALID]
```

CASMHMS-6073

## Issues and Related PRs

* Resolves [CASMHMS-6073](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6073)

## Testing

Tested on:

  * mug using a new build of the cray cli

Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N


## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
